### PR TITLE
Domain fuzzing with TLD support in strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,58 @@ A Golang typosquat generator utilizing various strategies to generate potential 
 
 See files under `cmd/` for example usage.
 
+### Fuzz
+
+```
+all := []strategy.Strategy{
+	strategy.Omission,
+	strategy.Repetition,
+}
+
+results, err := typogenerator.Fuzz("zenithar", all...)
+if err != nil {
+	fmt.Println(err)
+}
+
+for _, r := range results {
+	for _, p := range r.Permutations {
+		fmt.Println(p)
+	}
+}
+
+// enithar
+// znithar
+// zeithar
+// zenthar
+// ...
+```
+
+### FuzzDomain
+
+```
+all := []strategy.Strategy{
+	strategy.Omission,
+	strategy.Repetition,
+}
+
+results, err := typogenerator.FuzzDomain("example.com", all...)
+if err != nil {
+	fmt.Println(err)
+}
+
+for _, r := range results {
+	for _, p := range r.Permutations {
+		fmt.Println(p)
+	}
+}
+
+// xample.com
+// eample.com
+// exmple.com
+// exaple.com
+// ...
+```
+
 ## Fuzzing Algorithms (strategies)
 
 1. **Addition** - Addition of a single character to the end of a string

--- a/strategy/addition.go
+++ b/strategy/addition.go
@@ -11,11 +11,13 @@ type additionStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *additionStrategy) Generate(domain string) ([]string, error) {
+func (s *additionStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	for i := 97; i < 123; i++ {
-		res = append(res, fmt.Sprintf("%s%c", domain, i))
+		fuzzed := fmt.Sprintf("%s%c", domain, i)
+		fuzzed = combineTLD(fuzzed, tld)
+		res = append(res, fuzzed)
 	}
 
 	return res, nil

--- a/strategy/addition_test.go
+++ b/strategy/addition_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAddition(t *testing.T) {
-	out, err := strategy.Addition.Generate("zenithar")
+	out, err := strategy.Addition.Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/bitsquatting.go
+++ b/strategy/bitsquatting.go
@@ -15,17 +15,19 @@ type bitsquattingStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *bitsquattingStrategy) Generate(dom string) ([]string, error) {
+func (s *bitsquattingStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	masks := []int32{1, 2, 4, 8, 16, 32, 64, 128}
 
-	for i, c := range dom {
+	for i, c := range domain {
 		for m := range masks {
 			b := rune(int(c) ^ m)
 			o := int(b)
 			if (o >= 48 && o <= 57) || (o >= 97 && o <= 122) || o == 45 {
-				res = append(res, fmt.Sprintf("%s%c%s", dom[:i], b, dom[i+1:]))
+				fuzzed := fmt.Sprintf("%s%c%s", domain[:i], b, domain[i+1:])
+				fuzzed = combineTLD(fuzzed, tld)
+				res = append(res, fuzzed)
 			}
 		}
 	}

--- a/strategy/bitsquatting_test.go
+++ b/strategy/bitsquatting_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBitSquatting(t *testing.T) {
-	out, err := strategy.BitSquatting.Generate("zenithar")
+	out, err := strategy.BitSquatting.Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/doublehit.go
+++ b/strategy/doublehit.go
@@ -20,7 +20,7 @@ func DoubleHit(m mapping.Mapping) Strategy {
 
 // -----------------------------------------------------------------------------
 
-func (s *doublehitStrategy) Generate(domain string) ([]string, error) {
+func (s *doublehitStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	dom := []rune(domain)
@@ -29,8 +29,13 @@ func (s *doublehitStrategy) Generate(domain string) ([]string, error) {
 		keys := s._mapping.GetMapping(dom[i])
 		if len(keys) > 0 {
 			for _, c := range keys {
-				res = append(res, fmt.Sprintf("%s%c%c%s", string(dom[:i]), c, dom[i], string(dom[i+1:])))
-				res = append(res, fmt.Sprintf("%s%c%c%s", string(dom[:i]), dom[i], c, string(dom[i+1:])))
+				fuzzed := fmt.Sprintf("%s%c%c%s", string(dom[:i]), c, dom[i], string(dom[i+1:]))
+				fuzzed = combineTLD(fuzzed, tld)
+				res = append(res, fuzzed)
+
+				fuzzed = fmt.Sprintf("%s%c%c%s", string(dom[:i]), dom[i], c, string(dom[i+1:]))
+				fuzzed = combineTLD(fuzzed, tld)
+				res = append(res, fuzzed)
 			}
 		}
 	}

--- a/strategy/doublehit_test.go
+++ b/strategy/doublehit_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDoubleHit(t *testing.T) {
-	out, err := strategy.DoubleHit(mapping.French).Generate("zenithar")
+	out, err := strategy.DoubleHit(mapping.French).Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/helpers.go
+++ b/strategy/helpers.go
@@ -1,0 +1,9 @@
+package strategy
+
+func combineTLD(domain, tld string) string {
+	if tld == "" {
+		return domain
+	}
+
+	return domain + "." + tld
+}

--- a/strategy/homoglyph.go
+++ b/strategy/homoglyph.go
@@ -15,7 +15,7 @@ type homoglyphStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *homoglyphStrategy) Generate(domain string) ([]string, error) {
+func (s *homoglyphStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 	// `ᅟᅠ         　ㅤǃ！״″＂＄％＆＇﹝（﹞）⁎＊＋‚，‐𐆑－٠۔܁܂․‧。．｡⁄∕╱⫻⫽／ﾉΟοОоՕ𐒆ＯｏΟοОоՕ𐒆Ｏｏا
 	//１２３４５６𐒇７Ց８９։܃܄∶꞉：;；‹＜𐆐＝›＞？＠［＼］＾＿｀
@@ -79,7 +79,9 @@ func (s *homoglyphStrategy) Generate(domain string) ([]string, error) {
 						if len(g) > 1 {
 							j++
 						}
-						res = append(res, fmt.Sprintf("%s%s%s", string(dom[:i]), string(win), string(dom[i+ws:])))
+						fuzzed := fmt.Sprintf("%s%s%s", string(dom[:i]), string(win), string(dom[i+ws:]))
+						fuzzed = combineTLD(fuzzed, tld)
+						res = append(res, fuzzed)
 					}
 				}
 				j++

--- a/strategy/homoglyph_test.go
+++ b/strategy/homoglyph_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHomoglyph(t *testing.T) {
-	out, err := strategy.Homoglyph.Generate("zemithar")
+	out, err := strategy.Homoglyph.Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)
@@ -17,7 +17,7 @@ func TestHomoglyph(t *testing.T) {
 		t.FailNow()
 	}
 
-	if len(out) != 87 {
+	if len(out) != 90 {
 		t.FailNow()
 	}
 }

--- a/strategy/hyphenation.go
+++ b/strategy/hyphenation.go
@@ -11,12 +11,14 @@ type hyphenationStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *hyphenationStrategy) Generate(dom string) ([]string, error) {
+func (s *hyphenationStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
-	for i := 1; i < len(dom)-1; i++ {
-		if (rune(dom[i]) != '-' || rune(dom[i]) != '.') && (rune(dom[i-1]) != '-' || rune(dom[i-1]) != '.') {
-			res = append(res, fmt.Sprintf("%s-%s", dom[:i], dom[i:]))
+	for i := 1; i < len(domain)-1; i++ {
+		if (rune(domain[i]) != '-' || rune(domain[i]) != '.') && (rune(domain[i-1]) != '-' || rune(domain[i-1]) != '.') {
+			fuzzed := fmt.Sprintf("%s-%s", domain[:i], domain[i:])
+			fuzzed = combineTLD(fuzzed, tld)
+			res = append(res, fuzzed)
 		}
 	}
 

--- a/strategy/hyphenation_test.go
+++ b/strategy/hyphenation_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHyphenation(t *testing.T) {
-	out, err := strategy.Hyphenation.Generate("zemithar")
+	out, err := strategy.Hyphenation.Generate("zemithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/interface.go
+++ b/strategy/interface.go
@@ -2,6 +2,6 @@ package strategy
 
 // Strategy defines domain generation strategy contracts
 type Strategy interface {
-	Generate(string) ([]string, error)
+	Generate(domain, tld string) ([]string, error)
 	GetName() string
 }

--- a/strategy/omission.go
+++ b/strategy/omission.go
@@ -11,11 +11,13 @@ type omissionStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *omissionStrategy) Generate(dom string) ([]string, error) {
+func (s *omissionStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
-	for i := range dom {
-		res = append(res, fmt.Sprintf("%s%s", dom[:i], dom[i+1:]))
+	for i := range domain {
+		fuzzed := fmt.Sprintf("%s%s", domain[:i], domain[i+1:])
+		fuzzed = combineTLD(fuzzed, tld)
+		res = append(res, fuzzed)
 	}
 
 	return res, nil

--- a/strategy/omission_test.go
+++ b/strategy/omission_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestOmission(t *testing.T) {
-	out, err := strategy.Omission.Generate("zemithar")
+	out, err := strategy.Omission.Generate("zemithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/prefix.go
+++ b/strategy/prefix.go
@@ -12,11 +12,13 @@ type prefixStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *prefixStrategy) Generate(domain string) ([]string, error) {
+func (s *prefixStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	for _, prefix := range s.prefixes {
-		res = append(res, fmt.Sprintf("%s%s", prefix, domain))
+		fuzzed := fmt.Sprintf("%s%s", prefix, domain)
+		fuzzed = combineTLD(fuzzed, tld)
+		res = append(res, fuzzed)
 	}
 
 	return res, nil

--- a/strategy/prefix_test.go
+++ b/strategy/prefix_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPrefix(t *testing.T) {
-	out, err := strategy.Prefix.Generate("zemithar")
+	out, err := strategy.Prefix.Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)
@@ -17,7 +17,7 @@ func TestPrefix(t *testing.T) {
 		t.FailNow()
 	}
 
-	if len(out) != 14 {
+	if len(out) != 22 {
 		t.FailNow()
 	}
 }

--- a/strategy/repetition.go
+++ b/strategy/repetition.go
@@ -15,12 +15,14 @@ type repetitionStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *repetitionStrategy) Generate(dom string) ([]string, error) {
+func (s *repetitionStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
-	for i, c := range dom {
+	for i, c := range domain {
 		if helpers.IsAlpha(c) {
-			res = append(res, fmt.Sprintf("%s%c%c%s", dom[:i], dom[i], dom[i], dom[i+1:]))
+			fuzzed := fmt.Sprintf("%s%c%c%s", domain[:i], domain[i], domain[i], domain[i+1:])
+			fuzzed = combineTLD(fuzzed, tld)
+			res = append(res, fuzzed)
 		}
 	}
 

--- a/strategy/repetition_test.go
+++ b/strategy/repetition_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRepetition(t *testing.T) {
-	out, err := strategy.Repetition.Generate("zemithar")
+	out, err := strategy.Repetition.Generate("zemithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/replace.go
+++ b/strategy/replace.go
@@ -20,7 +20,7 @@ func Replace(m mapping.Mapping) Strategy {
 
 // -----------------------------------------------------------------------------
 
-func (s *replaceStrategy) Generate(domain string) ([]string, error) {
+func (s *replaceStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	dom := []rune(domain)
@@ -29,7 +29,9 @@ func (s *replaceStrategy) Generate(domain string) ([]string, error) {
 		keys := s._mapping.GetMapping(dom[i])
 		if len(keys) > 0 {
 			for _, c := range keys {
-				res = append(res, fmt.Sprintf("%s%c%s", string(dom[:i]), c, string(dom[i+1:])))
+				fuzzed := fmt.Sprintf("%s%c%s", string(dom[:i]), c, string(dom[i+1:]))
+				fuzzed = combineTLD(fuzzed, tld)
+				res = append(res, fuzzed)
 			}
 		}
 	}

--- a/strategy/replace_test.go
+++ b/strategy/replace_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestReplace(t *testing.T) {
-	out, err := strategy.Replace(mapping.French).Generate("zenithar")
+	out, err := strategy.Replace(mapping.French).Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/similar.go
+++ b/strategy/similar.go
@@ -20,7 +20,7 @@ func Similar(m mapping.Mapping) Strategy {
 
 // -----------------------------------------------------------------------------
 
-func (s *similarStrategy) Generate(domain string) ([]string, error) {
+func (s *similarStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	dom := []rune(domain)
@@ -37,7 +37,9 @@ func (s *similarStrategy) Generate(domain string) ([]string, error) {
 				if len(repList) > 0 {
 					for _, g := range repList {
 						win = []rune(fmt.Sprintf("%s%c%s", string(win[:j]), g, string(win[j+1:])))
-						res = append(res, fmt.Sprintf("%s%s%s", string(dom[:i]), string(win), string(dom[i+ws:])))
+						fuzzed := fmt.Sprintf("%s%s%s", string(dom[:i]), string(win), string(dom[i+ws:]))
+						fuzzed = combineTLD(fuzzed, tld)
+						res = append(res, fuzzed)
 					}
 				}
 

--- a/strategy/similar_test.go
+++ b/strategy/similar_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSimilar(t *testing.T) {
-	out, err := strategy.Similar(mapping.French).Generate("zenithar")
+	out, err := strategy.Similar(mapping.French).Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/subdomain.go
+++ b/strategy/subdomain.go
@@ -11,14 +11,16 @@ type subdomainStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *subdomainStrategy) Generate(domain string) ([]string, error) {
+func (s *subdomainStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
 	dom := []rune(domain)
 
 	for i := 1; i < len(dom); i++ {
 		if (rune(dom[i]) != '-' || rune(dom[i]) != '.') && (rune(dom[i-1]) != '-' || rune(dom[i-1]) != '.') {
-			res = append(res, fmt.Sprintf("%s.%s", string(dom[:i]), string(dom[i:])))
+			fuzzed := fmt.Sprintf("%s.%s", string(dom[:i]), string(dom[i:]))
+			fuzzed = combineTLD(fuzzed, tld)
+			res = append(res, fuzzed)
 		}
 	}
 

--- a/strategy/subdomain_test.go
+++ b/strategy/subdomain_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSubdomain(t *testing.T) {
-	out, err := strategy.SubDomain.Generate("zenithar")
+	out, err := strategy.SubDomain.Generate("zenithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/transposition.go
+++ b/strategy/transposition.go
@@ -11,12 +11,14 @@ type transpositionStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *transpositionStrategy) Generate(dom string) ([]string, error) {
+func (s *transpositionStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 
-	for i := 0; i < len(dom)-1; i++ {
-		if dom[i+1] != dom[i] {
-			res = append(res, fmt.Sprintf("%s%c%c%s", dom[:i], dom[i+1], dom[i], dom[i+2:]))
+	for i := 0; i < len(domain)-1; i++ {
+		if domain[i+1] != domain[i] {
+			fuzzed := fmt.Sprintf("%s%c%c%s", domain[:i], domain[i+1], domain[i], domain[i+2:])
+			fuzzed = combineTLD(fuzzed, tld)
+			res = append(res, fuzzed)
 		}
 	}
 

--- a/strategy/transposition_test.go
+++ b/strategy/transposition_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTransposition(t *testing.T) {
-	out, err := strategy.Transposition.Generate("zemithar")
+	out, err := strategy.Transposition.Generate("zemithar", "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)

--- a/strategy/vowelswap.go
+++ b/strategy/vowelswap.go
@@ -11,7 +11,7 @@ type vowelwapStrategy struct {
 
 // -----------------------------------------------------------------------------
 
-func (s *vowelwapStrategy) Generate(domain string) ([]string, error) {
+func (s *vowelwapStrategy) Generate(domain, tld string) ([]string, error) {
 	res := []string{}
 	vowels := []rune{'a', 'e', 'i', 'o', 'u', 'y'}
 
@@ -22,7 +22,9 @@ func (s *vowelwapStrategy) Generate(domain string) ([]string, error) {
 			switch dom[i] {
 			case 'a', 'e', 'i', 'o', 'u', 'y':
 				if dom[i] != v {
-					res = append(res, fmt.Sprintf("%s%c%s", string(dom[:i]), v, string(dom[i+1:])))
+					fuzzed := fmt.Sprintf("%s%c%s", string(dom[:i]), v, string(dom[i+1:]))
+					fuzzed = combineTLD(fuzzed, tld)
+					res = append(res, fuzzed)
 				}
 			default:
 			}

--- a/strategy/vowelswap_test.go
+++ b/strategy/vowelswap_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestVowelSwap(t *testing.T) {
 	in := "zenithar"
-	out, err := strategy.VowelSwap.Generate(in)
+	out, err := strategy.VowelSwap.Generate(in, "")
 	if err != nil {
 		t.Fail()
 		t.Fatal("Error should not occurs !", err)


### PR DESCRIPTION
Relates to [Issue #2](https://github.com/Zenithar/go-typogenerator/issues/2).

- Add `FuzzDomain` to handle TLD splitting
- Leaves the `Fuzz` api intact
- `Generate()` is TLD aware for all strategies
- Update README with examples
- Also fixes some broken tests