### PR TITLE
Add TLD Replace and TLD Repeat strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See files under `cmd/` for example usage.
 
 ### Fuzz
 
-```
+```go
 all := []strategy.Strategy{
 	strategy.Omission,
 	strategy.Repetition,
@@ -34,7 +34,7 @@ for _, r := range results {
 
 ### FuzzDomain
 
-```
+```go
 all := []strategy.Strategy{
 	strategy.Omission,
 	strategy.Repetition,
@@ -73,6 +73,8 @@ for _, r := range results {
 1. **SubDomain** - Addition of a period `.` between the first and last character in a string
 1. **Transposition** - Swapping of adjacent characters in a string
 1. **VowelSwap** - Swapping of vowels in string with all other vowels
+1. **TLDReplace** - Replaces the TLD with a list of commonly used TLDs. Only works with `FuzzDomain`.
+1. **TLDRepeat** - Repeats the TLD after the domain name. Only works with `FuzzDomain`.
 
 ## Languages
 

--- a/strategy/tldrepeat.go
+++ b/strategy/tldrepeat.go
@@ -1,0 +1,34 @@
+package strategy
+
+import "fmt"
+
+var (
+	TLDRepeat Strategy
+)
+
+type tldRepeatStrategy struct {
+}
+
+// -----------------------------------------------------------------------------
+
+func (s *tldRepeatStrategy) Generate(domain, tld string) ([]string, error) {
+	res := []string{}
+
+	// Skip strategy if input is missing TLD
+	if tld == "" {
+		return res, nil
+	}
+
+	fuzzed := fmt.Sprintf("%s%s.%s", domain, tld, tld)
+	res = append(res, fuzzed)
+
+	return res, nil
+}
+
+func init() {
+	TLDRepeat = &tldRepeatStrategy{}
+}
+
+func (s *tldRepeatStrategy) GetName() string {
+	return "TLDRepeat"
+}

--- a/strategy/tldrepeat_test.go
+++ b/strategy/tldrepeat_test.go
@@ -1,0 +1,35 @@
+package strategy_test
+
+import (
+	"testing"
+
+	"github.com/Zenithar/typogenerator/strategy"
+)
+
+func TestTLDRepeat(t *testing.T) {
+	out, err := strategy.TLDRepeat.Generate("example", "com")
+	if err != nil {
+		t.Fail()
+		t.Fatal("Error should not occur !", err)
+	}
+
+	if len(out) != 1 {
+		t.FailNow()
+	}
+
+	if out[0] != "examplecom.com" {
+		t.FailNow()
+	}
+}
+
+func TestTLDRepeatMissingTLD(t *testing.T) {
+	out, err := strategy.TLDRepeat.Generate("example", "")
+	if err != nil {
+		t.Fail()
+		t.Fatal("Error should not occur !", err)
+	}
+
+	if len(out) != 0 {
+		t.FailNow()
+	}
+}

--- a/strategy/tldreplace.go
+++ b/strategy/tldreplace.go
@@ -1,0 +1,128 @@
+package strategy
+
+import "fmt"
+
+var (
+	TLDReplace Strategy
+)
+
+type tldReplaceStrategy struct {
+}
+
+// Top list generated from:
+// https://w3techs.com/technologies/overview/top_level_domain/all
+var topTLDs = []string{
+	"com",
+	"ru",
+	"org",
+	"net",
+	"de",
+	"jp",
+	"uk",
+	"br",
+	"it",
+	"pl",
+	"fr",
+	"in",
+	"ir",
+	"au",
+	"info",
+	"cn",
+	"nl",
+	"es",
+	"cz",
+	"kr",
+	"ca",
+	"ua",
+	"eu",
+	"co",
+	"gr",
+	"ro",
+	"za",
+	"ch",
+	"se",
+	"tw",
+	"biz",
+	"hu",
+	"vn",
+	"mx",
+	"be",
+	"at",
+	"tr",
+	"dk",
+	"me",
+	"ar",
+	"tv",
+	"sk",
+	"no",
+	"us",
+	"fi",
+	"cl",
+	"id",
+	"io",
+	"xyz",
+	"pt",
+	"by",
+	"il",
+	"ie",
+	"nz",
+	"kz",
+	"lt",
+	"hk",
+	"cc",
+	"my",
+	"club",
+	"sg",
+	"top",
+	"bg",
+	"рф",
+	"edu",
+	"th",
+	"su",
+	"pk",
+	"hr",
+	"rs",
+	"pro",
+	"si",
+	"lv",
+	"az",
+	"pe",
+	"download",
+	"ae",
+	"ph",
+	"ee",
+	"online",
+	"ng",
+	"pw",
+	"cat",
+	"ve",
+}
+
+// -----------------------------------------------------------------------------
+
+func (s *tldReplaceStrategy) Generate(domain, tld string) ([]string, error) {
+	res := []string{}
+
+	// Skip strategy if input is missing TLD
+	if tld == "" {
+		return res, nil
+	}
+
+	for _, topTLD := range topTLDs {
+		if tld == topTLD {
+			continue
+		}
+		fuzzed := fmt.Sprintf("%s.%s", domain, topTLD)
+		res = append(res, fuzzed)
+	}
+
+	return res, nil
+}
+
+func init() {
+	TLDReplace = &tldReplaceStrategy{}
+}
+
+func (s *tldReplaceStrategy) GetName() string {
+	return "TLDReplace"
+}

--- a/strategy/tldreplace_test.go
+++ b/strategy/tldreplace_test.go
@@ -1,0 +1,35 @@
+package strategy_test
+
+import (
+	"testing"
+
+	"github.com/Zenithar/typogenerator/strategy"
+)
+
+func TestTLDReplace(t *testing.T) {
+	out, err := strategy.TLDReplace.Generate("example", "com")
+	if err != nil {
+		t.Fail()
+		t.Fatal("Error should not occur !", err)
+	}
+
+	if len(out) == 0 {
+		t.FailNow()
+	}
+
+	if len(out) != 83 {
+		t.FailNow()
+	}
+}
+
+func TestTLDReplaceMissingTLD(t *testing.T) {
+	out, err := strategy.TLDReplace.Generate("example", "")
+	if err != nil {
+		t.Fail()
+		t.Fatal("Error should not occur !", err)
+	}
+
+	if len(out) != 0 {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
- Adds 2 TLD Strategies
- Updates README

Feedback welcome on the TLD Replace strategy. I sourced a list of top used domains as the replacements for TLDs. Originally I had planned to use the publicsuffix list but there are over 1500 TLDs and that would generate a large list. I instead took a similar approached used by the Prefix strategy.